### PR TITLE
feat: Experimental typed `URLSearchParamsString`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@denosaurs/typefetch",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "exports": {
     ".": "./main.ts"
   },

--- a/main.ts
+++ b/main.ts
@@ -23,6 +23,7 @@ if (import.meta.main) {
       "include-base-url",
       "include-server-urls",
       "include-relative-url",
+      "experimental-urlsearchparams",
     ],
     alias: { "output": "o", "help": "h", "version": "V" },
     default: {
@@ -31,6 +32,7 @@ if (import.meta.main) {
       "include-base-url": false,
       "include-server-urls": true,
       "include-relative-url": false,
+      "experimental-urlsearchparams": false,
     },
     unknown: (arg, key) => {
       if (key === undefined) return;
@@ -48,15 +50,16 @@ if (import.meta.main) {
     console.log(
       `Usage: typefetch [OPTIONS] <PATH>\n\n` +
       `Options:\n` +
-      `  -h, --help                  Print this help message\n` +
-      `  -V, --version               Print the version of TypeFetch\n` +
-      `  -o, --output   <PATH>       Output file path                                            (default: typefetch.d.ts)\n` +
-      `      --config   <PATH>       File path to the tsconfig.json file\n` +
-      `      --import   <PATH>       Import path for TypeFetch                                   (default: https://raw.githubusercontent.com/denosaurs/typefetch/main)\n` +
-      `      --base-url <URL>        A custom base url for paths to start with\n` +
-      `      --include-base-url      Include the base url in the generated paths                 (default: false)\n` +
-      `      --include-server-urls   Include server URLs from the schema in the generated paths  (default: true)\n` +
-      `      --include-relative-url  Include relative URLs in the generated paths                (default: false)\n`,
+      `  -h, --help                          Print this help message\n` +
+      `  -V, --version                       Print the version of TypeFetch\n` +
+      `  -o, --output   <PATH>               Output file path                                            (default: typefetch.d.ts)\n` +
+      `      --config   <PATH>               File path to the tsconfig.json file\n` +
+      `      --import   <PATH>               Import path for TypeFetch                                   (default: https://raw.githubusercontent.com/denosaurs/typefetch/main)\n` +
+      `      --base-url <URL>                A custom base url for paths to start with\n` +
+      `      --include-base-url              Include the base url in the generated paths                 (default: false)\n` +
+      `      --include-server-urls           Include server URLs from the schema in the generated paths  (default: true)\n` +
+      `      --include-relative-url          Include relative URLs in the generated paths                (default: false)\n` +
+      `      --experimental-urlsearchparams  Enable the experimental fully typed URLSearchParams type    (default: false)\n`,
     );
     Deno.exit(0);
   }
@@ -98,6 +101,7 @@ if (import.meta.main) {
     includeBaseUrl: args["include-base-url"],
     includeServerUrls: args["include-server-urls"],
     includeRelativeUrl: args["include-relative-url"],
+    experimentalURLSearchParams: args["experimental-urlsearchparams"],
   };
 
   const project = new Project({ tsConfigFilePath: args.config });
@@ -112,6 +116,16 @@ if (import.meta.main) {
     }`,
     namedImports: ["JSONString"],
   });
+
+  if (options.experimentalURLSearchParams) {
+    source.addImportDeclaration({
+      isTypeOnly: true,
+      moduleSpecifier: `${args["import"]}/types/urlsearchparams${
+        URL.canParse(args["import"]) ? ".ts" : ""
+      }`,
+      namedImports: ["URLSearchParamsString"],
+    });
+  }
 
   source.insertText(0, (writer) => {
     writeModuleComment(writer, openapi.info);

--- a/mod.ts
+++ b/mod.ts
@@ -361,15 +361,21 @@ export function toTemplateString(
   options: Options,
 ): string {
   let patternTemplateString = pattern;
+  let urlSearchParamsOptional = true;
   const urlSearchParamsRecord = [];
 
   for (const parameter of parameters.values()) {
     if (parameter.in === "query") {
-      const optional = !parameter.required ? "?" : "";
+      if (parameter.required) {
+        urlSearchParamsOptional = false;
+      }
+
       const types = [toSchemaType(document, parameter.schema) ?? "string"];
       if (parameter.allowEmptyValue === true) types.push("true");
       urlSearchParamsRecord.push(
-        `${escapeObjectKey(parameter.name)}${optional}: ${types.join("|")}`,
+        `${escapeObjectKey(parameter.name)}${!parameter.required ? "?" : ""}: ${
+          types.join("|")
+        }`,
       );
     }
 
@@ -384,6 +390,8 @@ export function toTemplateString(
   const URLSearchParams = urlSearchParamsRecord.length > 0
     ? options.experimentalURLSearchParams
       ? `\${URLSearchParamsString<{${urlSearchParamsRecord.join(";")}}>}`
+      : urlSearchParamsOptional
+      ? '${"" | `?${string}`}'
       : "?${string}"
     : "";
 

--- a/types/urlsearchparams.ts
+++ b/types/urlsearchparams.ts
@@ -1,0 +1,99 @@
+// Copyright 2023 Elias Sjögreen. All rights reserved. MIT license.
+// deno-fmt-ignore-file
+
+/**
+ * You are in for a ride.
+ * 
+ * This file essentially only implements a single type: `URLSearchParamsString`.
+ * It is a generic template string type which enforces the structure and
+ * contents of string to conform to the passed record type.
+ * 
+ * The type is complex, slow and may be "excessively deep and possibly infinite"
+ * so maybe don't use it in anything you want to be fast but it  was a fun
+ * exercise which I may enable behind a flag.
+ * 
+ * @module
+ */
+
+type URLSearchParamsValue = string | number | boolean | undefined | null;
+type URLSearchParamsRecord = Record<string, URLSearchParamsValue>;
+type URLSearchParamsKeyValue<K extends string, V extends URLSearchParamsValue> =
+  V extends true ? `${K}=true` | K
+                 : `${K}=${NonNullable<V>}`;
+
+/**
+ * Recursively join the generic tuple of strings `A` into a single string
+ * delimited by the generic `S`. The generic `R` is used to accumulate the
+ * result.
+ */
+type Join<A extends readonly string[], S extends string = "", R extends string = ""> =
+  // Early exit if the tuple is empty
+    A extends [] ? R
+  // Split out the head and tail of the tuple. Assert the type of the head and
+  // tail, we need to do this to get narrowing even though it is guaranteed by
+  // the type signature of the generic `A`.
+  : A extends [infer Head, ...infer Tail] ? Head extends string ? Tail extends string[]
+    // We skip the delimiter if the head is an empty string. This essentially
+    // filters out any empty strings from the tuple.
+    ? Head extends "" ? Join<Tail, S, R>
+    // Join the tail with the head and the delimiter. If the accumulator is
+    // empty we skip the delimiter. This is to avoid leading delimiters.
+    : Join<Tail, S, R extends "" ? `${Head}` : `${R}${S}${Head}`>
+  : never : never
+  // Finally return the accumulated result.
+  : R;
+
+/** Prefixes the generic `S` with `P` if `S` is not an empty string */
+type Prefix<S extends string, P extends string> = S extends "" ? "" : `${P}${S}`;
+
+/** Replaces never values with an empty string */
+type ReplaceNever<T> = [T] extends [never] ? "" : T;
+
+/**
+ * Recursively generate a union of tuples in all possible orders and
+ * combinations of the generic union `T`. The generic `R` is used to accumulate
+ * the result.
+ * 
+ * @example MayInclude<"a" | "b"> = [] | ["a"] | ["b", "a"] | ["b"] | ["a", "b"]
+ */
+type MayInclude<T extends string, R extends readonly string[] = []> = R | { [K in T]: MayInclude<Exclude<T, K>, [K, ...R]> }[T];
+
+/**
+ * Recursively generate a union of tuples in all possible orders of the generic
+ * union `T`.
+ * 
+ * @example MustInclude<"a" | "b"> = ["a", "b"] | ["b", "a"]
+ * @example MustInclude<"a" | "b" | "c"> = ["a", "b", "c"] | ["a", "c", "b"] | ["b", "a", "c"] | ["b", "c", "a"] | ["c", "a", "b"] | ["c", "b", "a"]
+ */
+type MustInclude<T extends string> = { [K in T]: Exclude<T, K> extends never ? [K] : [K, ...MustInclude<Exclude<T, K>>] }[T];
+
+/**
+ * Extracts all required search params as a union of `URLSearchParamsKeyValue`
+ * from the generic `T`.
+ */
+type RequiredURLSearchParams<T extends URLSearchParamsRecord> = {
+  [K in keyof T]-?: K extends string
+  ? undefined extends T[K] ? never
+  : null extends T[K] ? never
+  : URLSearchParamsKeyValue<K, T[K]>
+  : never
+}[keyof T];
+
+/**
+ * Extracts all optional search params as a union of `URLSearchParamsKeyValue`
+ * from the generic `T`.
+ */
+type OptionalURLSearchParams<T extends URLSearchParamsRecord> = {
+  [K in keyof T]-?: K extends string
+  ? undefined extends T[K] ? URLSearchParamsKeyValue<K, T[K]>
+  : null extends T[K] ? URLSearchParamsKeyValue<K, T[K]>
+  : never
+  : never
+}[keyof T];
+
+/**
+ * Converts a generic `URLSearchParamsRecord` into a string that can be used as
+ * a query string in a URL.
+ */
+export type URLSearchParamsString<T extends URLSearchParamsRecord> =
+  Prefix<Join<[Join<MustInclude<ReplaceNever<RequiredURLSearchParams<T>>>>, Join<MayInclude<OptionalURLSearchParams<T>>, "&">], "&">, "?">;

--- a/types/urlsearchparams.ts
+++ b/types/urlsearchparams.ts
@@ -1,4 +1,3 @@
-// Copyright 2023 Elias Sjögreen. All rights reserved. MIT license.
 // deno-fmt-ignore-file
 
 /**


### PR DESCRIPTION
You are in for a ride.

This PR implements a fully typed `URLSearchParamsString` which validates `URLSearchParams` strings. I recommend the comments in [urlsearchparams.ts](./types/urlsearchparams.ts) if you want to understand more of this black magic!

To enable it for your projects use the `--experimental-urlsearchparams` flag.

Partially solves #3 but I still have lots of ideas on how to do that more efficiently at compile time instead.