### PR TITLE
feat: Experimental `--discriminator` and `--require-discriminator`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@denosaurs/typefetch",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "exports": {
     ".": "./main.ts"
   },

--- a/main.ts
+++ b/main.ts
@@ -17,6 +17,7 @@ const parseOptions = {
     "config",
     "import",
     "base-urls",
+    "experimental-discriminator",
   ],
   boolean: [
     "help",
@@ -24,6 +25,7 @@ const parseOptions = {
     "include-server-urls",
     "include-relative-url",
     "experimental-urlsearchparams",
+    "experimental-require-discriminator",
   ],
   alias: { "output": "o", "help": "h", "version": "V" },
   default: {
@@ -35,6 +37,8 @@ const parseOptions = {
     "include-absolute-url": false,
     "include-relative-url": false,
     "experimental-urlsearchparams": false,
+    "experimental-discriminator": false,
+    "experimental-require-discriminator": false,
   },
   unknown: (arg: string, key?: string) => {
     if (key === undefined) return;
@@ -54,16 +58,18 @@ if (args.help) {
   console.log(
     `Usage: typefetch [OPTIONS] <PATH>\n\n` +
     `Options:\n` +
-    `  -h, --help                          Print this help message\n` +
-    `  -V, --version                       Print the version of TypeFetch\n` +
-    `  -o, --output    <PATH>              Output file path                                                   (default: ${parseOptions.default["output"]})\n` +
-    `      --config    <PATH>              File path to the tsconfig.json file\n` +
-    `      --import    <PATH>              Import path for TypeFetch                                          (default: ${parseOptions.default["import"]})\n` +
-    `      --base-urls <URLS>              A comma separated list of custom base urls for paths to start with\n` +
-    `      --include-server-urls           Include server URLs from the schema in the generated paths         (default: ${parseOptions.default["include-server-urls"]})\n` +
-    `      --include-absolute-url          Include absolute URLs in the generated paths                       (default: ${parseOptions.default["include-absolute-url"]})\n` +
-    `      --include-relative-url          Include relative URLs in the generated paths                       (default: ${parseOptions.default["include-relative-url"]})\n` +
-    `      --experimental-urlsearchparams  Enable the experimental fully typed URLSearchParamsString type     (default: ${parseOptions.default["experimental-urlsearchparams"]})\n`,
+    `  -h, --help                                Print this help message\n` +
+    `  -V, --version                             Print the version of TypeFetch\n` +
+    `  -o, --output    <PATH>                    Output file path                                                   (default: ${parseOptions.default["output"]})\n` +
+    `      --config    <PATH>                    File path to the tsconfig.json file\n` +
+    `      --import    <PATH>                    Import path for TypeFetch                                          (default: ${parseOptions.default["import"]})\n` +
+    `      --base-urls <URLS>                    A comma separated list of custom base urls for paths to start with\n` +
+    `      --include-server-urls                 Include server URLs from the schema in the generated paths         (default: ${parseOptions.default["include-server-urls"]})\n` +
+    `      --include-absolute-url                Include absolute URLs in the generated paths                       (default: ${parseOptions.default["include-absolute-url"]})\n` +
+    `      --include-relative-url                Include relative URLs in the generated paths                       (default: ${parseOptions.default["include-relative-url"]})\n` +
+    `      --experimental-urlsearchparams        Enable the experimental fully typed URLSearchParamsString type     (default: ${parseOptions.default["experimental-urlsearchparams"]})\n` +
+    `      --experimental-discriminator          Allows you to specify a discriminator generic argument to fetch    (default: ${parseOptions.default["experimental-discriminator"]})\n` +
+    `      --experimental-require-discriminator  Makes the use of a discriminator generic argument required         (default: ${parseOptions.default["experimental-require-discriminator"]})\n`,
   );
   Deno.exit(0);
 }
@@ -111,6 +117,8 @@ const options = {
   includeServerUrls: args["include-server-urls"],
   includeRelativeUrl: args["include-relative-url"],
   experimentalURLSearchParams: args["experimental-urlsearchparams"],
+  discriminator: args["experimental-discriminator"],
+  requireDiscriminator: args["experimental-require-discriminator"],
 };
 
 const project = new Project({ tsConfigFilePath: args.config });

--- a/mod.ts
+++ b/mod.ts
@@ -687,7 +687,9 @@ export function addOperationObject(
     typeParameters.push({
       name: "T",
       constraint: discriminatorType,
-      default: options.experimentalRequireDiscriminator ? undefined : discriminatorType,
+      default: options.experimentalRequireDiscriminator
+        ? undefined
+        : discriminatorType,
     });
   }
 


### PR DESCRIPTION
See #10

Still very experimental.

Allows you to generate fetch types which look like the following:
```typescript
// With --experimental-discriminator=api
function fetch<T extends "api" = "api">(input: `/api/v1/users/login`);

// With --experimental-discriminator=api --experimental-require-discriminator
function fetch<T extends "api">(input: `/api/v1/users/login`);
```

This is also helpful for projects which are using multiple different backends as a way of namespacing the types for each:

```typescript
// With --experimental-discriminator=imdb --experimental-require-discriminator
function fetch<T extends "imdb">(input: `/api/v1/movies`);

// With --experimental-discriminator=api --experimental-require-discriminator
function fetch<T extends "api">(input: `/api/v1/users/login`);
```

---

To use the `fetch` with a discriminator specified you simply need to pass it as the first generic argument:

```typescript
// With --experimental-discriminator=api --experimental-require-discriminator
function fetch<T extends "api">(input: `/api/v1/users/login`);

// Works!
fetch<"api">("/api/v1/users/login", { ... });

// Fails!
fetch<"imdb">("/api/v1/users/login", { ... });

// Falls back to the default `fetch` type which isn't going to be typed.
// When not using the `--experimental-require-discriminator` flag this
// will still work as before. E.g. returning the types if any are found
// matching the function signature.
fetch("/api/v1/users/login", { ... });
```